### PR TITLE
Safari popup render

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,26 +1,18 @@
 <template>
   <div>
     <!-- Safari Disclaimer Popup -->
-    <div
-      v-if="showSafariDisclaimer"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
-      @keydown.esc="closeSafariDisclaimer"
-      tabindex="0"
-      aria-modal="true"
-      role="dialog"
-    >
+    <div v-if="showSafariDisclaimer" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
+      @keydown.esc="closeSafariDisclaimer" tabindex="0" aria-modal="true" role="dialog">
       <div class="bg-white rounded-lg shadow-lg max-w-sm w-full p-6 relative">
-        <button
-          @click="closeSafariDisclaimer"
-          class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
-          aria-label="Close"
-        >
+        <button @click="closeSafariDisclaimer" class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+          aria-label="Close">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
         <div class="flex items-center mb-3">
-          <svg class="w-6 h-6 text-blue-500 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="w-6 h-6 text-blue-500 mr-2" fill="none" stroke="currentColor" stroke-width="2"
+            viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
           <span class="font-semibold text-lg">Safari Notice</span>
@@ -28,10 +20,8 @@
         <p class="text-gray-700 mb-2">
           For the best experience, consider using Chrome or Firefox. Some features may not work as expected in Safari.
         </p>
-        <button
-          @click="closeSafariDisclaimer"
-          class="mt-4 w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition"
-        >
+        <button @click="closeSafariDisclaimer"
+          class="mt-4 w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition">
           Got it!
         </button>
       </div>
@@ -69,9 +59,10 @@
       <div class="flex justify-between items-center px-4 py-2">
         <div class="flex items-center space-x-2">
           <a href="https://rrup.org/">
-            <img src="/public/images/rrup_logo.png" alt="Rainbow Roundup Logo" class="h-12 w-auto" href="https://rrup.org/"/>
+            <img src="/public/images/rrup_logo.png" alt="Rainbow Roundup Logo" class="h-12 w-auto"
+              href="https://rrup.org/" />
           </a>
-          
+
         </div>
 
         <!-- Navigation Links -->
@@ -126,28 +117,29 @@
         </button>
       </div>
 
-      <!-- Collapsible Navigation Menu (when page is resized)-->
-     <div v-show="mobileMenuOpen" class="xl:hidden bg-white border-t border-gray-200 shadow-lg">
+      <!-- Collapsible Mobile Navigation Menu (when page is resized)-->
+      <div v-if="mobileMenuOpen"
+        class="xl:hidden bg-white border-t border-gray-200 shadow-lg absolute left-0 right-0 top-full"
+        style="z-index:100">
         <nav class="flex flex-col space-y-1 px-4 py-3 text-sm font-medium">
-          <NuxtLink to="/" @click="navigate('Home')"
-            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Home</NuxtLink>
-          <NuxtLink to="/aboutUs" @click="navigate('About Us')"
-            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">About Us</NuxtLink>
-          <NuxtLink to="/calendar" @click="navigate('Calendar')"
-            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Calendar</NuxtLink>
-          <a href="https://buy.stripe.com/test_14k6op0Et2oF9xKaEE" @click="navigate('Donate')"
-            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Donate</a>
-          <NuxtLink v-if="!session" to="/signup" @click="navigate('Sign Up')"
-            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Sign Up/Log In</NuxtLink>
-          <button v-else @click="logout"
-            class="block py-2 text-left text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">
-            Logout
-          </button>
-          <button @click="promptInstall"
-            class="block py-2 text-left text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">
-            Install App
-          </button>
-          <button @click="requestNotificationPermission"
+          <NuxtLink to="/" class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
+            @click.native="handleMobileNavClick">Home</NuxtLink>
+          <NuxtLink to="/aboutUs" class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
+            @click.native="handleMobileNavClick">About Us</NuxtLink>
+          <NuxtLink to="/calendar" class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
+            @click.native="handleMobileNavClick">Calendar</NuxtLink>
+          <a href="https://buy.stripe.com/test_14k6op0Et2oF9xKaEE"
+            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
+            @click="handleMobileNavClick">Donate</a>
+          <NuxtLink v-if="!session" to="/signup"
+            class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
+            @click.native="handleMobileNavClick">Sign Up/Log In</NuxtLink>
+          <button v-else @click="logout(); handleMobileNavClick()"
+            class="block py-2 text-left text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Logout</button>
+          <button @click="promptInstall(); handleMobileNavClick()"
+            class="block py-2 text-left text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Install
+            App</button>
+          <button @click="requestNotificationPermission(); handleMobileNavClick()"
             class="flex items-center py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
             aria-label="Toggle notifications">
             <span class="mr-2">Notifications</span>
@@ -181,11 +173,22 @@ import { ref, onMounted } from "vue";
 // Use the built-in auth composable instead of custom useUser
 const { data: session, signOut } = useAuth();
 
-const dropdownOpen = ref(false);
+const dropdownOpen = ref(false); 
 const mobileMenuOpen = ref(false);
 const isSubscribed = ref(false);
 const deferredPrompt = ref(null);
 
+// Toggles resized mobile menu view
+const toggleMobileMenu = () => {
+  mobileMenuOpen.value = !mobileMenuOpen.value;
+};
+
+// Closes the resized mobile menu once a nav link is clicked
+const handleMobileNavClick = () => {
+  mobileMenuOpen.value = false;
+};
+
+// Tracks if disclaimer has already been shown
 const showSafariDisclaimer = ref(false);
 
 // Safari detection function

--- a/app.vue
+++ b/app.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <!-- Safari Disclaimer Popup -->
-    <div v-if="showSafariDisclaimer" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
+    <div v-if="showSafariDisclaimer" class="fixed inset-0 z-50 flex items-center justify-center"
       @keydown.esc="closeSafariDisclaimer" tabindex="0" aria-modal="true" role="dialog">
-      <div class="bg-white rounded-lg shadow-lg max-w-sm w-full p-6 relative">
+      <div class="bg-white rounded-lg shadow-lg max-w-sm w-full p-6 relative border border-gray-200">
         <button @click="closeSafariDisclaimer" class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
           aria-label="Close">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -26,8 +26,6 @@
         </button>
       </div>
     </div>
-  </div>
-  <div>
     <!-- PWA Manifest and Route Announcer -->
     <NuxtPwaManifest />
     <NuxtRouteAnnouncer />
@@ -173,7 +171,7 @@ import { ref, onMounted } from "vue";
 // Use the built-in auth composable instead of custom useUser
 const { data: session, signOut } = useAuth();
 
-const dropdownOpen = ref(false); 
+const dropdownOpen = ref(false);
 const mobileMenuOpen = ref(false);
 const isSubscribed = ref(false);
 const deferredPrompt = ref(null);

--- a/app.vue
+++ b/app.vue
@@ -1,27 +1,77 @@
 <template>
   <div>
+    <!-- Safari Disclaimer Popup -->
+    <div
+      v-if="showSafariDisclaimer"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
+      @keydown.esc="closeSafariDisclaimer"
+      tabindex="0"
+      aria-modal="true"
+      role="dialog"
+    >
+      <div class="bg-white rounded-lg shadow-lg max-w-sm w-full p-6 relative">
+        <button
+          @click="closeSafariDisclaimer"
+          class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+          aria-label="Close"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <div class="flex items-center mb-3">
+          <svg class="w-6 h-6 text-blue-500 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span class="font-semibold text-lg">Safari Notice</span>
+        </div>
+        <p class="text-gray-700 mb-2">
+          For the best experience, consider using Chrome or Firefox. Some features may not work as expected in Safari.
+        </p>
+        <button
+          @click="closeSafariDisclaimer"
+          class="mt-4 w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition"
+        >
+          Got it!
+        </button>
+      </div>
+    </div>
+  </div>
+  <div>
     <!-- PWA Manifest and Route Announcer -->
     <NuxtPwaManifest />
     <NuxtRouteAnnouncer />
+
     <div class="bg-blue-600 text-white text-sm px-4 py-1">
       <div class="flex justify-between items-center max-w-7xl mx-auto">
-        <div class="flex items-center gap-2">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5}
-            stroke="currentColor" class="size-4">
-            <path strokeLinecap="round" strokeLinejoin="round"
-              d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
-          </svg>
-          <a href="mailto:info@rainbowroundup.org" class="underline hover:text-blue-200">
-            info@rrup.org
-          </a>
+        <!-- Left side: email with icon -->
+        <div class="flex items-center gap-2 flex-grow">
+          <div class="flex items-center space-x-1">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+              stroke="currentColor" class="w-4 h-4">
+              <path stroke-linecap="round" stroke-linejoin="round"
+                d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+            </svg>
+            <a href="mailto:info@rainbowroundup.org" class="underline hover:text-blue-200">
+              info@rrup.org
+            </a>
+          </div>
         </div>
-        469-443-8993
+
+        <!-- Right side: phone number -->
+        <div class="shrink-0 pl-4">
+          469-443-8993
+        </div>
       </div>
     </div>
+
     <div class="sticky top-0 z-50 bg-white shadow-sm">
       <div class="flex justify-between items-center px-4 py-2">
         <div class="flex items-center space-x-2">
-          <img src="/public/images/rrup_logo.png" alt="Rainbow Roundup Logo" class="h-12 w-auto" />
+          <a href="https://rrup.org/">
+            <img src="/public/images/rrup_logo.png" alt="Rainbow Roundup Logo" class="h-12 w-auto" href="https://rrup.org/"/>
+          </a>
+          
         </div>
 
         <!-- Navigation Links -->
@@ -77,7 +127,7 @@
       </div>
 
       <!-- Collapsible Navigation Menu (when page is resized)-->
-      <div v-if="mobileMenuOpen" class="xl:hidden bg-white border-t border-gray-200 shadow-lg">
+     <div v-show="mobileMenuOpen" class="xl:hidden bg-white border-t border-gray-200 shadow-lg">
         <nav class="flex flex-col space-y-1 px-4 py-3 text-sm font-medium">
           <NuxtLink to="/" @click="navigate('Home')"
             class="block py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Home</NuxtLink>
@@ -136,14 +186,47 @@ const mobileMenuOpen = ref(false);
 const isSubscribed = ref(false);
 const deferredPrompt = ref(null);
 
-if (typeof window !== "undefined") {
-  window.addEventListener("beforeinstallprompt", (e) => {
-    e.preventDefault();
-    deferredPrompt.value = e;
-    console.log("Deferred prompt captured (composition API)");
-  });
-}
+const showSafariDisclaimer = ref(false);
 
+// Safari detection function
+const isSafari = () => {
+  if (typeof window === "undefined") return false;
+  const ua = window.navigator.userAgent;
+  // Detect Safari (not Chrome, not Firefox, not Edge)
+  return (
+    /Safari/.test(ua) &&
+    !/Chrome|Chromium|Edg|Firefox/.test(ua)
+  );
+};
+
+// Close Safari disclaimer
+const closeSafariDisclaimer = () => {
+  showSafariDisclaimer.value = false;
+  if (typeof window !== "undefined") {
+    sessionStorage.setItem("safariDisclaimerDismissed", "true");
+  }
+};
+
+// Handle ESC key press
+const handleKeyPress = (event) => {
+  if (event.key === "Escape" && showSafariDisclaimer.value) {
+    closeSafariDisclaimer();
+  }
+};
+
+onMounted(() => {
+  updateSubscriptionStatus();
+
+  // Safari disclaimer logic
+  if (
+    typeof window !== "undefined" &&
+    isSafari() &&
+    sessionStorage.getItem("safariDisclaimerDismissed") !== "true"
+  ) {
+    showSafariDisclaimer.value = true;
+    window.addEventListener("keydown", handleKeyPress);
+  }
+});
 const toggleDropdown = () => {
   dropdownOpen.value = !dropdownOpen.value;
 };
@@ -196,9 +279,6 @@ const requestNotificationPermission = () => {
   }
 };
 
-onMounted(() => {
-  updateSubscriptionStatus();
-});
 
 const logout = async () => {
   await signOut({ callbackUrl: "/" });


### PR DESCRIPTION
There's an issue where the header looks black before the user clicks on button to dismiss popup, but it goes back to blue afterwards. Not sure why there's an issue, but header looks ok across all browsers afterwards.
<img width="1646" height="1089" alt="Screenshot 2025-07-23 at 2 06 11 PM" src="https://github.com/user-attachments/assets/125ce05d-6c57-4650-8ffa-41ad250f49fc" />
<img width="1651" height="1044" alt="Screenshot 2025-07-23 at 2 06 05 PM" src="https://github.com/user-attachments/assets/86221f73-f42c-4798-9e93-98562ba06aa5" />
<img width="1687" height="973" alt="Screenshot 2025-07-23 at 2 05 39 PM" src="https://github.com/user-attachments/assets/f1508457-01ed-4d2c-bd1e-53dc3196388e" />
<img width="1683" height="1087" alt="Screenshot 2025-07-23 at 2 05 25 PM" src="https://github.com/user-attachments/assets/53f8016b-6f5a-42f2-a287-a4f668966af7" />
