### PR TITLE
Email Case error, use toLowerCase

### DIFF
--- a/server/api/verify.post.ts
+++ b/server/api/verify.post.ts
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
     // Move to User table
     const user = await prisma.user.create({
       data: {
-        email: pending.email,
+        email: (pending.email as string).toLowerCase(), //"as string" is NOT a boiler plate, Do not remove
         firstname: pending.firstname,
         lastname: pending.lastname,
         phoneNum: pending.phoneNum,


### PR DESCRIPTION
When user registers an email using uppercase, the database saves it as the uppercase which may cause errors in log-ins. I used "as string.toLowerCase()" in verify.post.ts to save the email in the database as completely lower case. The "as string" is not a boiler and should not be removed although the email is already type string (I'm not sure why).