### PR TITLE
change "from" header in email system

### DIFF
--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -25,7 +25,8 @@ export default NuxtAuthHandler({
           pass: config.smtpPass, // SMTP password
         },
       },
-      from: "noreply@example.com", // Default sender email address for verification emails
+      
+      from: config.smtpFrom, // Default sender email address for verification emails
       sendVerificationRequest({
         identifier: email,
         url,


### PR DESCRIPTION
This fixes #251, where login emails have an incorrect header that may lead to some email services to refuse to send emails (as with mine), or if the email does get sent (as with the email in .env), it may more easily get flagged as spam. It isn't a huge issue but might cause problems in future.

More info about the bug in #251.