### PR TITLE
fix database

### DIFF
--- a/prisma/migrations/20251023213607_add_plus_one_kids_adults/migration.sql
+++ b/prisma/migrations/20251023213607_add_plus_one_kids_adults/migration.sql
@@ -8,53 +8,6 @@
   - Added the required column `itemVariantId` to the `OrderItem` table without a default value. This is not possible if the table is not empty.
 
 */
--- DropTable
-PRAGMA foreign_keys=off;
-DROP TABLE "FinishedItem";
-PRAGMA foreign_keys=on;
-
--- DropTable
-PRAGMA foreign_keys=off;
-DROP TABLE "Item";
-PRAGMA foreign_keys=on;
-
--- CreateTable
-CREATE TABLE "ItemVariant" (
-    "id" TEXT NOT NULL PRIMARY KEY,
-    "size" TEXT NOT NULL,
-    "price" REAL NOT NULL,
-    "itemId" TEXT NOT NULL,
-    CONSTRAINT "ItemVariant_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "AbstractItem" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
-);
-
--- CreateTable
-CREATE TABLE "AbstractItem" (
-    "id" TEXT NOT NULL PRIMARY KEY,
-    "name" TEXT NOT NULL
-);
-
--- RedefineTables
-PRAGMA defer_foreign_keys=ON;
-PRAGMA foreign_keys=OFF;
-CREATE TABLE "new_ItemPhoto" (
-    "id" TEXT NOT NULL PRIMARY KEY,
-    "url" TEXT NOT NULL,
-    "itemId" TEXT NOT NULL,
-    CONSTRAINT "ItemPhoto_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "AbstractItem" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
-);
-INSERT INTO "new_ItemPhoto" ("id", "itemId", "url") SELECT "id", "itemId", "url" FROM "ItemPhoto";
-DROP TABLE "ItemPhoto";
-ALTER TABLE "new_ItemPhoto" RENAME TO "ItemPhoto";
-CREATE TABLE "new_OrderItem" (
-    "id" TEXT NOT NULL PRIMARY KEY,
-    "orderId" TEXT NOT NULL,
-    "itemVariantId" TEXT NOT NULL,
-    CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-    CONSTRAINT "OrderItem_itemVariantId_fkey" FOREIGN KEY ("itemVariantId") REFERENCES "ItemVariant" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
-);
-INSERT INTO "new_OrderItem" ("id", "orderId") SELECT "id", "orderId" FROM "OrderItem";
-DROP TABLE "OrderItem";
-ALTER TABLE "new_OrderItem" RENAME TO "OrderItem";
 CREATE TABLE "new_SignUp" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "userId" TEXT NOT NULL,


### PR DESCRIPTION
Remove the random sql commands in a prisma migration that is from another migration and is actively harming the migration. 

This fixes #258 

To test:
- go to main branch
- try to reset your database and confirm that it fails
- switch to this branch, issue258-fixDB
- try to reset your database and confirm that it works.
