### PR TITLE
Make the notification button work properly, rename for clarity

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -83,7 +83,7 @@
             Install App
           </button>
           <!-- This is hidden if your browser does not support it, so I dont have to figure out a pretty way to write the error message-->
-          <button @click="requestNotificationPermission();console.log('subscription: ',notifSubscription)" v-if="($pwa.getSWRegistration()?.pushManager)" 
+          <button @click="requestNotificationPermission();console.log('subscription: ',notifSubscription); showNotifError = true" v-if="($pwa.getSWRegistration()?.pushManager)" 
             class="flex items-center  text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
             aria-label="Toggle notifications">
             <span class="mr-2">Device notifications</span>
@@ -101,10 +101,9 @@
                   d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
               </svg>
             </span>
-            <span class="text-sm font-light float-start	">{{ notificationError }}</span>
+            
           </button>
         </nav>
-
         <!-- Hamburger Button - md: sizing -->
         <button @click="toggleMobileMenu"
           class="md:hidden flex items-center justify-center w-8 h-8 text-gray-700 hover:text-black focus:outline-none"
@@ -150,7 +149,7 @@
             class="block py-2 text-left text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2">Install
             App</button>
           <button @click="requestNotificationPermission(); handleMobileNavClick()"
-            class="flex items-center py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2"
+            class="flex items-center py-2 text-gray-700 hover:text-black hover:bg-gray-50 rounded px-2 border-0"
             aria-label="Toggle notifications">
             <span class="mr-2">Device notifications</span>
             <span v-if="isSubscribedToPush">
@@ -171,6 +170,12 @@
           </button>
         </nav>
       </div>
+      <span class="fixed box-border w-60 shadow-lg h-auto top-20 right-0 z-50 text-center items-center justify-center float-right bg-inherit rounded-lg p-1  border-gray-400 active:bg-gray-200 hover:bg-gray-200" v-if="showNotifError && notificationError.value" tabindex="0" aria-modal="true" role="dialog">
+        <NuxtLink to="/login" @click="showNotifError = false">
+          
+        {{ notificationError }}
+        </NuxtLink>
+      </span>
     </div>
 
     <!-- Nuxt Page Component to display content -->
@@ -193,7 +198,7 @@ const deferredPrompt = ref(null);
 const runtimeConfig = useRuntimeConfig();
 const notificationError = ref(null);
 const isSubscribedToPush = ref(false);
-
+const showNotifError = ref(false);
 const { $pwa } = useNuxtApp();
 const notifSubscription = ref(null)
 // Toggles resized mobile menu view
@@ -318,12 +323,12 @@ notificationError.value = computed(() => {
       return null;
     }
     else {
-      return "Please login to register notifications";  
+      return "Login to register notifications";  
     }
   }
 })
 const requestNotificationPermission = () => {
-  if ("serviceWorker" in navigator && "Notification" in window) {
+  if ("serviceWorker" in navigator && "Notification" in window && session?.value?.data?.user?.id) {
     Notification.requestPermission()
       .then(async (permission) => {
         console.log("Permission:", permission);

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -100,7 +100,7 @@ const submitOTP = async () => {
       <div class="text-lg mt-6 text-center text-gray-600">
         <strong>
           Don't have an account?
-          <a href="./signUp" class="text-[#D97ED5] hover:underline transition">Sign Up</a>
+          <NuxtLink to="/signup" class="text-[#D97ED5] hover:underline transition">Sign Up</NuxtLink>
         </strong>
       </div>
     </form>

--- a/pages/signUp.vue
+++ b/pages/signUp.vue
@@ -65,9 +65,9 @@
       <div class="text-md mt-6 text-center text-gray-600">
         <strong>
           Already have an account?
-          <a href="./login" class="text-[#D97ED5] hover:underline transition">
+          <NuxtLink to="/login" class="text-[#D97ED5] hover:underline transition">
             Sign In
-          </a>
+          </NuxtLink>
         </strong>
       </div>
 


### PR DESCRIPTION
This should fix #216, but I also decided to refactor how the button is displayed. Since before it was a hack that did not properly work. So I changed the following
1. Renamed it to "Device Notifications" to make it clear to the user what this is
2. Added it to the landscape version of the website
    - However only if the browser actually supports push notifications
    - This is different from the portrait mode, where it still shows up with an error message
    - I did this because I couldn't figure out how to nicely display the error message, plus this *should* be fine since I imagine most tablets should support push notifications
    - Though there is a somewhat ugly message for non-logged in users
3. Refactored the code that checks if the user is subscribed to notifications
    - it previously only cared about whether the browser gave notification permission
    - Now there is code to actually check if the user has subscribed to notifications on the client side
    - It does not confirm with the server that the subscription exists in our db, but that *should* be fine since we are unlikely to reset the db in production.


To Test:
Note: I know that Chrome on desktop definitely supports these notifications.
1. On a landscape device (ie: a laptop), go to homepage and confirm that the bell icon is slashed (ie: not subscribed to notifications)
    - If you are not logged in, it should also show you the message telling you to login 
2. Then login, the message telling you to login should disappear.
3. Then click the device notification button, you should get a notification and the bell icon should not be slashed.
4. To test on a browser that does not support this, please check on firefox desktop since the dev build cannot do notifications for firefox
    - Here, the notification button should disappear entirely
    - Testing on some other browser without notification support works for this if you dont have firefox