### PR TITLE
Put images in user a directory with userid of the image uploader

### DIFF
--- a/components/EditItem.vue
+++ b/components/EditItem.vue
@@ -134,7 +134,7 @@ const editedItem = reactive({
     description: props.item.description,
     isArchived: props.item.isArchived,
     ItemVariants: props.item.ItemVariants.map(a => {return {...a}}),
-    ItemPhotos: props.item.ItemPhotos.map(a => {return {...a}}) || [],
+    ItemPhotos: props.item.ItemPhotos || [],
 });
 function closeWindow() {
     emit("closeWindow");

--- a/server/api/itemPhoto/[id].delete.ts
+++ b/server/api/itemPhoto/[id].delete.ts
@@ -36,8 +36,7 @@ export default defineEventHandler(async (event: any) => {
 
     const filePath = path.join(
         config.UPLOAD_DIR || "public/uploads",
-        path.dirname(itemPhoto.url).split("/").at(-1) + "", // extract the user id directory name from itemPhoto, since path.basename strips it. 
-        // The + " " is because of typescipt complaining
+        path.dirname(itemPhoto.url).split("/").at(-1) as string, // extract the user id directory name from itemPhoto, since path.basename strips it. 
         path.basename(itemPhoto.url)
     );
 

--- a/server/api/itemPhoto/index.post.ts
+++ b/server/api/itemPhoto/index.post.ts
@@ -57,7 +57,7 @@ export default defineEventHandler(async (event: any) => {
     );
     
     if (!fs.existsSync(fileDir)){ // Create user directory if it does not exist
-        fs.mkdirSync(fileDir);
+        fs.mkdirSync(fileDir, {recursive: true}); // added recursive parameter to multiple directories if needed (ie when uploads directory is not yet there)
     }
     const filePath = path.join(
         fileDir,

--- a/server/api/user/profile_picture/index.post.ts
+++ b/server/api/user/profile_picture/index.post.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
   )
 
   if (!fs.existsSync(fileDir)) { // Create user directory if it does not exist
-    fs.mkdirSync(fileDir);
+    fs.mkdirSync(fileDir, {recursive: true}); // added recursive parameter to multiple directories if needed (ie when uploads directory is not yet there)
   }
   if (!file) return (setResponseStatus(event, 400), { error: "No file" })
   if (!file.data?.length) return (setResponseStatus(event, 400), { error: "Empty upload" })


### PR DESCRIPTION
This takes the images uploaded and puts them in a directory with user id. Meaning if the user id is 1234 and the image is profile.png, the image will go in /1234/profile.png. This is to better separate images and reduce the chance of collisions that happen when two people upload at once.

I remember discussing this, and believe this was the desired implementation, though I can rework it if not. I believe this should not be affected by the difference in dev vs prod.

However I noticed an issue in /profile/[id].vue and the edititem component when adding images to an item. Namely that in the dev enviroment, you cannot actually see the profile picture. This is because it the resolution (client) side of the image is relative to the current url of the page. Meaning in the profile page, it will try to fetch it from /profile/(image url in db), which obviously returns a 404. A similar thing happens when displaying the image in the edittem menu. This issue exists outside the changes introduced in PR (it seems to be present in the staging branch when I tested it at least).

I should mention that the images do display in /merchandise and /profile/index, which seem to fetch the image and then pass it to the renderer instead of giving it the relative url and telling it to figure it out. I am leaving this here in case I forget to fix this later.