### PR TITLE
automate prisma migrations

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -10,8 +10,17 @@ RUN pnpm prisma generate
 RUN pnpm run build
 
 FROM node:current-alpine AS deployment
-
 COPY --from=builder /.output /
-# COPY --from=builder /prisma/client /prisma/client
+COPY --from=builder /package.json /
+COPY --from=builder /pnpm-lock.yaml /
+COPY --from=builder /prisma /prisma
+COPY --from=builder /node_modules /node_modules
+
+RUN npm i -g pnpm
+COPY ./entrypoint.sh /entrypoint.sh
+# Ensure we can actually run the entrypoint script
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 3000
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "./server/index.mjs"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Apply migrations and initialize migrations if it does not exist
+pnpm prisma generate
+pnpm prisma migrate deploy
+
+# Run the CMD command from the dockerfile
+exec "$@"


### PR DESCRIPTION
This modifies the dockerfile and adds an entrypoint.sh to automate prisma migrations. The idea being, everytime the container starts, `prisma generate` and `prisma migrate deploy` will automatically run.

This will result in a larger build size of the docker container since we need to copy node modules for this to work. However, we can instead delete the entire git cloned repo (as well as the node modules) from the host system. I have tested this locally and it seems to work on my machine.