### PR TITLE
remove duplicate prisma calls in server

### DIFF
--- a/server/api/archive/event/index.get.ts
+++ b/server/api/archive/event/index.get.ts
@@ -1,6 +1,5 @@
 // gets **ARCHIVED** events
 
-import { PrismaClient } from "@prisma/client";
 import { auth } from "~/server/auth"
 import type { User } from "@prisma/client"
 

--- a/server/api/archive/report/index.get.ts
+++ b/server/api/archive/report/index.get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+
 import { auth } from "~/server/auth"
 import type { User } from "@prisma/client"
 

--- a/server/api/archive/user/index.get.ts
+++ b/server/api/archive/user/index.get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 import { auth } from "~/server/auth"
 import type { User } from "@prisma/client"
 

--- a/server/api/event/[id].delete.ts
+++ b/server/api/event/[id].delete.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 import { defineEventHandler } from "h3";
 //import { getServerSession } from "#auth";
 import { auth } from "~/server/auth"

--- a/server/api/event/[id].get.ts
+++ b/server/api/event/[id].get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 //import { getServerSession } from "#auth";
 import { auth } from "~/server/auth"

--- a/server/api/event/[id].put.ts
+++ b/server/api/event/[id].put.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 import {
   defineEventHandler,
   getRouterParam,

--- a/server/api/event/index.get.ts
+++ b/server/api/event/index.get.ts
@@ -1,6 +1,6 @@
 // gets **UNARCHIVED** events
 
-import { PrismaClient, User } from "@prisma/client";
+import  type { User } from "@prisma/client";
 import { auth } from "~/server/auth";
 //created the type for labeling variables for computing the Capacity signup function. If you dont like this lmk.
 type SignUpCounts = {

--- a/server/api/item/[id].put.ts
+++ b/server/api/item/[id].put.ts
@@ -15,7 +15,6 @@ body should include:
 import { defineEventHandler, setResponseStatus, getRouterParam, createError, readBody } from "h3";
 import type { User } from "../../../types/session";
 import { auth } from "~/server/auth"
-import { Size } from "@prisma/client"
 
 export default defineEventHandler(async (event) => {
     const id = getRouterParam(event, "id");

--- a/server/api/item/index.post.ts
+++ b/server/api/item/index.post.ts
@@ -2,7 +2,6 @@ import { defineEventHandler, setResponseStatus, createError, readBody } from "h3
 import type { User } from "../../../types/session";
 import { auth } from "~/server/auth"
 import { Size } from "@prisma/client";
-import { type Prisma } from '@prisma/client'
 
 export default defineEventHandler(async (event) => {
     const prisma = event.context.prisma;

--- a/server/api/report/[id].delete.ts
+++ b/server/api/report/[id].delete.ts
@@ -1,5 +1,4 @@
 import { EventImpl } from '@fullcalendar/core/internal.js';
-import { PrismaClient } from '@prisma/client';
 import { auth } from "~/server/auth"
 import type { User } from "@prisma/client";
 

--- a/server/api/report/[id].get.ts
+++ b/server/api/report/[id].get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+
 import { auth } from "~/server/auth"
 import type { User } from "@prisma/client";
 

--- a/server/api/report/index.get.ts
+++ b/server/api/report/index.get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+
 import { auth } from "~/server/auth"
 import type { User } from "@prisma/client";
 

--- a/server/api/report/index.post.ts
+++ b/server/api/report/index.post.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+
 import type { User } from "@prisma/client";
 import { auth } from '~/server/auth';
 

--- a/server/api/signup/[id].delete.ts
+++ b/server/api/signup/[id].delete.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import { auth } from '~/server/auth';
 import type { User } from "../../../types/session";

--- a/server/api/signup/[id].get.ts
+++ b/server/api/signup/[id].get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, User } from "@prisma/client";
+
 import { auth } from "~/server/auth";
 import { defineEventHandler } from "h3";
 import SignUp from "~/pages/signUp.vue";

--- a/server/api/signup/index.get.ts
+++ b/server/api/signup/index.get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, User } from "@prisma/client";
+import type { User } from "@prisma/client";
 //import SignUp from "~/pages/signUp.vue";
 import { auth } from "~/server/auth";
 

--- a/server/api/signup/index.post.ts
+++ b/server/api/signup/index.post.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Event } from "@prisma/client";
+
 import { defineEventHandler, readBody, setResponseStatus } from "h3";
 //import { getServerSession } from "#auth";
 import { auth } from '~/server/auth';

--- a/server/api/signup/lookup.get.ts
+++ b/server/api/signup/lookup.get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, User } from "@prisma/client";
+import type { PrismaClient, User } from "@prisma/client";
 import { defineEventHandler, getQuery, setResponseStatus } from "h3";
 import { auth } from "~/server/auth";
 

--- a/server/api/user/[id].delete.ts
+++ b/server/api/user/[id].delete.ts
@@ -1,7 +1,6 @@
 // used for users to delete their own account. to ban, use PUT and change isBanned flag to true
 
 import { EventImpl } from "@fullcalendar/core/internal.js";
-import { PrismaClient } from "@prisma/client";
 import { auth } from "~/server/auth"
 import type { User } from "../../../types/session";
 

--- a/server/api/user/[id].get.ts
+++ b/server/api/user/[id].get.ts
@@ -3,7 +3,7 @@ There is an issue in how user: singleUser is being returned and what [id].vue is
 Cannot log in properly, profile page is not working, and data is not being populated for user.
 SEEMS TO BE FIXED: 6/28
 */
-import { PrismaClient } from "@prisma/client";
+
 import { auth } from "~/server/auth"
 import type { User } from "../../../types/session";
 

--- a/server/api/user/[id].put.ts
+++ b/server/api/user/[id].put.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+
 import { auth } from "~/server/auth"
 import type { User } from "../../../types/session";
 

--- a/server/api/user/batch/index.post.ts
+++ b/server/api/user/batch/index.post.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 
 export default defineEventHandler(async (event) => {
   const prisma = event.context.prisma;

--- a/server/api/user/index.get.ts
+++ b/server/api/user/index.get.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, User } from "@prisma/client";
+import type {  User } from "@prisma/client";
 import { auth } from "~/server/auth";
 
 export default defineEventHandler(async (event) => {

--- a/server/api/verify.post.ts
+++ b/server/api/verify.post.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+
 import { defineEventHandler, readBody, setResponseStatus, setCookie } from "h3";
 
 export default defineEventHandler(async (event) => {


### PR DESCRIPTION
I have tried to completely remove imports for prisma client in the API. In most cases, the import was for the type and not the whole class, so I added the type keyword so the build only gets the type and nothing else.

This may help with the memory leak